### PR TITLE
Upgrade stylelint to v7.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   "author": "Palantir",
   "license": "Apache-2.0",
   "dependencies": {
-    "stylelint-config-standard": "11.0.0"
+    "stylelint-config-standard": "16.0.0"
   },
   "devDependencies": {
-    "stylelint": "7.0.3",
+    "stylelint": "7.8.0",
     "stylelint-scss": "1.2.1"
   },
   "peerDependencies": {
-    "stylelint": "^7.0.3"
+    "stylelint": "^7.8.0"
   },
   "optionalDependencies": {
     "stylelint-scss": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "Palantir",
   "license": "Apache-2.0",
   "dependencies": {
-    "stylelint-config-standard": "16.0.0"
+    "stylelint-config-standard": "16.0.0",
+    "stylelint-order": "0.2.2"
   },
   "devDependencies": {
     "stylelint": "7.8.0",

--- a/sass.js
+++ b/sass.js
@@ -11,7 +11,7 @@ module.exports = {
   "rules": {
     "at-rule-empty-line-before": ["always", {
       except: ["first-nested"],
-      ignore: ["after-comment", "blockless-group"],
+      ignore: ["after-comment", "blockless-after-blockless"],
       // allow @else to come on same line as closing @if brace
       ignoreAtRules: ["else"],
     }],

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -60,7 +60,7 @@ module.exports = {
     "selector-root-no-composition": true,
     "string-quotes": "double",
     "stylelint-disable-reason": "always-before",
-    "time-no-imperceptible": true,
+    "time-min-milliseconds": 100,
     "unit-blacklist": ["pt"],
     "value-keyword-case": "lower",
     "value-list-comma-newline-before": "never-multi-line",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -43,7 +43,7 @@ module.exports = {
     "number-no-trailing-zeros": true,
     "property-no-unknown": true,
     "property-no-vendor-prefix": true,
-    "rule-nested-empty-line-before": ["always-multi-line", {
+    "rule-empty-line-before": ["always-multi-line", {
       except: ["first-nested"],
       ignore: ["after-comment"],
     }],

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -10,7 +10,6 @@ module.exports = {
   namingPattern,
 
   plugins: [
-    // this is an optionalDependency in NPM
     "stylelint-order",
   ],
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -9,6 +9,11 @@ module.exports = {
   // export namingPattern so it can be used in your own rules
   namingPattern,
 
+  plugins: [
+    // this is an optionalDependency in NPM
+    "stylelint-order",
+  ],
+
   rules: {
     "at-rule-no-unknown": true,
     "at-rule-no-vendor-prefix": true,
@@ -16,10 +21,6 @@ module.exports = {
     "color-hex-length": "long",
     "color-named": "never",
     "declaration-block-no-duplicate-properties": true,
-    // property order is defined in a separate file for legibility
-    "declaration-block-properties-order": [require("./property-order.js"), {
-      unspecified: "bottomAlphabetical",
-    }],
     "declaration-block-semicolon-newline-after": "always",
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-colon-newline-after": null,
@@ -65,5 +66,18 @@ module.exports = {
     "value-keyword-case": "lower",
     "value-list-comma-newline-before": "never-multi-line",
     "value-no-vendor-prefix": true,
+    "order/declaration-block-order": [[
+      "custom-properties",
+      "dollar-variables",
+      "declarations",
+      "rules",
+      "at-rules",
+    ], {
+      unspecified: "bottom"
+    }],
+    // property order is defined in a separate file for legibility
+    "order/declaration-block-properties-specified-order": [require("./property-order.js"), {
+      unspecified: "bottomAlphabetical",
+    }],
   },
 };

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -43,7 +43,6 @@ module.exports = {
     "number-no-trailing-zeros": true,
     "property-no-unknown": true,
     "property-no-vendor-prefix": true,
-    "root-no-standard-properties": true,
     "rule-nested-empty-line-before": ["always-multi-line", {
       except: ["first-nested"],
       ignore: ["after-comment"],
@@ -57,9 +56,7 @@ module.exports = {
     "selector-no-id": true,
     "selector-no-universal": true,
     "selector-no-vendor-prefix": true,
-    "selector-root-no-composition": true,
     "string-quotes": "double",
-    "stylelint-disable-reason": "always-before",
     "time-min-milliseconds": 100,
     "unit-blacklist": ["pt"],
     "value-keyword-case": "lower",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -24,6 +24,9 @@ module.exports = {
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-colon-newline-after": null,
     "declaration-colon-space-after": "always",
+    "declaration-empty-line-before": ["never", {
+      ignore: ["after-declaration"],
+    }],
     "declaration-no-important": true,
     "font-family-name-quotes": "always-unless-keyword",
     "font-weight-notation": "numeric",

--- a/test/example.css
+++ b/test/example.css
@@ -2,6 +2,10 @@ html {
     box-sizing: border-box;
 }
 
+a {
+    animation: 100ms;
+}
+
 .overlay {
     position: absolute;
     top: 0;


### PR DESCRIPTION
I've done my best to upgrade `stylelint-config-palantir` to use the latest stylelint version.

- Added [`stylelint-order`](https://github.com/hudochenkov/stylelint-order) plugin to replace `declaration-block-properties-order` rule deprecation.
- Replaced some deprecated rules by alternatives.
- Removed all other deprecated rules.

I also thought of adding support for the [`declaration-block-property-groups-structure`](https://github.com/hudochenkov/stylelint-order/blob/master/rules/declaration-block-property-groups-structure/README.md) rule to force empty line before property groups (following the same group separation as the [property-order.js](/palantir/stylelint-config-palantir/blob/master/property-order.js) file), but this would break every project using this stylelint config and I decided against it. I can still do that if you're interested 😄.

Closes #9.