### PR TITLE
Fix some 8.0 warnings

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -56,8 +56,8 @@ module.exports = {
     "selector-max-compound-selectors": 4,
     // "id,class,type"
     "selector-max-specificity": "1,3,3",
-    "selector-no-id": true,
-    "selector-no-universal": true,
+    "selector-max-id": 0,
+    "selector-max-universal": 0,
     "selector-no-vendor-prefix": true,
     "string-quotes": "double",
     "time-min-milliseconds": 100,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -57,7 +57,7 @@ module.exports = {
     // "id,class,type"
     "selector-max-specificity": "1,3,3",
     "selector-max-id": 0,
-    "selector-max-universal": 0,
+    "selector-max-universal": 1,
     "selector-no-vendor-prefix": true,
     "string-quotes": "double",
     "time-min-milliseconds": 100,


### PR DESCRIPTION
```
Warning	stylelint	'selector-no-id' has been deprecated and in 8.0 will be removed. Instead use 'selector-max-id' with '0' as its primary option. (reference)
```
```
Warning	stylelint	'selector-no-universal' has been deprecated and in 8.0 will be removed. Instead use 'selector-max-universal' with '0' as its primary option. (reference)
```