### PR TITLE
Prepare 2.1.0 release with stylelint 8.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "stylelint-order": "^0.3.0"
   },
   "devDependencies": {
-    "stylelint": "^8.0.0",
-    "stylelint-scss": "^1.5.1"
+    "stylelint": "8.0.0",
+    "stylelint-scss": "1.5.1"
   },
   "peerDependencies": {
     "stylelint": "^7.12.0 || ~8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-palantir",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "stylelint configuration",
   "main": "stylelint.config.js",
   "scripts": {
@@ -23,15 +23,15 @@
   "author": "Palantir",
   "license": "Apache-2.0",
   "dependencies": {
-    "stylelint-config-standard": "^16.0.0",
+    "stylelint-config-standard": "^17.0.0",
     "stylelint-order": "^0.3.0"
   },
   "devDependencies": {
-    "stylelint": "7.9.0",
-    "stylelint-scss": "1.4.3"
+    "stylelint": "^8.0.0",
+    "stylelint-scss": "^1.5.1"
   },
   "peerDependencies": {
-    "stylelint": "^7.9.0"
+    "stylelint": "^7.12.0 || ~8.0.0"
   },
   "optionalDependencies": {
     "stylelint-scss": "^1.4.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "stylelint-scss": "1.5.1"
   },
   "peerDependencies": {
-    "stylelint": "^7.12.0 || ~8.0.0"
+    "stylelint": "^7.12.0 || ^8.0.0"
   },
   "optionalDependencies": {
     "stylelint-scss": "^1.4.3"

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -57,7 +57,7 @@ module.exports = {
     // "id,class,type"
     "selector-max-specificity": "1,3,3",
     "selector-max-id": 0,
-    "selector-max-universal": 1,
+    "selector-max-universal": 0,
     "selector-no-vendor-prefix": true,
     "string-quotes": "double",
     "time-min-milliseconds": 100,


### PR DESCRIPTION
#### Fixes #12 

- Update all dependencies
- Also reverts `selector-max-universal` limit to 0
- Bump package version to 2.1.0 so we're ready to release