### PR TITLE
Add optional leading "-" to names

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -6,7 +6,7 @@
 "use strict";
 
 // lowercase-single-dashed-names-only-0
-const namingPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const namingPattern = /^-?[a-z0-9]+(-[a-z0-9]+)*$/;
 
 module.exports = {
   extends: "stylelint-config-standard",


### PR DESCRIPTION
Support classnames like ".-selected" or ".-no-axis-label" (both examples from Jet)