### PR TITLE
Allow multi-line declarations for rules like grid-template

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -25,7 +25,7 @@ module.exports = {
     "color-hex-length": "long",
     "color-named": "never",
     "declaration-block-no-duplicate-properties": true,
-    "declaration-block-semicolon-newline-after": "always",
+    "declaration-block-semicolon-newline-after": "always-single-line",
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-colon-newline-after": null,
     "declaration-colon-space-after": "always",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -25,10 +25,10 @@ module.exports = {
     "color-hex-length": "long",
     "color-named": "never",
     "declaration-block-no-duplicate-properties": true,
-    "declaration-block-semicolon-newline-after": "always-single-line",
+    "declaration-block-semicolon-newline-after": "always",
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-colon-newline-after": null,
-    "declaration-colon-space-after": "always",
+    "declaration-colon-space-after": "always-single-line",
     "declaration-empty-line-before": ["never", {
       ignore: ["after-declaration"],
     }],


### PR DESCRIPTION
**Before:**
```css
grid-template: "header header"
    "selection details";
```

**After:**
```css
// okay
grid-template: "header header"
    "selection details";

// also okay
grid-template:
    "header header"
    "selection details";
```

This is super useful for the ASCII-style diagrams of grid-template, or multiple box-shadows, etc.