### PR TITLE
Swap unit-blacklist rule for unit-disallowed-list

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -72,7 +72,7 @@ module.exports = {
     }],
     "string-quotes": "double",
     "time-min-milliseconds": 100,
-    "unit-blacklist": ["pt"],
+    "unit-disallowed-list": ["pt"],
     "value-keyword-case": "lower",
     "value-list-comma-newline-before": "never-multi-line",
     "value-no-vendor-prefix": true,


### PR DESCRIPTION
Removes these warnings:

```
Deprecation Warning: 'unit-blacklist' has been deprecated. Instead use 'unit-disallowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/unit-blacklist/README.md
```