### PR TITLE
Enable dollar-variable-colon-space-after

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -35,6 +35,7 @@ module.exports = {
     "scss/at-import-partial-extension-blacklist": ["scss"],
     // "scss/at-mixin-argumentless-call-parentheses": "always", // TODO: coming in next stylelint-scss release
     "scss/at-mixin-pattern": namingPattern,
+    "scss/dollar-variable-colon-space-after": "always-single-line",
     "scss/dollar-variable-no-missing-interpolation": true,
     "scss/dollar-variable-pattern": namingPattern,
     "scss/media-feature-value-dollar-variable": "always",


### PR DESCRIPTION
Docs: https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/dollar-variable-colon-space-after/README.md

This follows the config level of `declaration-colon-space-after` to enforce this if single line is used:
https://github.com/palantir/stylelint-config-palantir/blob/4c747c6f2fa3a3fc6e78c551a8ef7080d0a01e0a/stylelint.config.js#L31

Note that there are a few other `dollar-variable-*` rules that might be worth reviewing for any other desired changes with the current `declaration-*` rules as well:
https://github.com/kristerkari/stylelint-scss/tree/master/src/rules

