### PR TITLE
Ignore property-no-unknown inside :export blocks

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -38,7 +38,9 @@ module.exports = {
     "no-duplicate-selectors": true,
     "no-unknown-animations": true,
     "number-max-precision": 8,
-    "property-no-unknown": true,
+    "property-no-unknown": [true, {
+      "ignoreSelectors": [":export"]
+    }],
     "property-no-vendor-prefix": true,
     "rule-empty-line-before": ["always-multi-line", {
       except: ["first-nested"],


### PR DESCRIPTION
This disables the `property-no-unknown` error inside `:export` blocks.