### PR TITLE
Remove deprecated rule

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -26,10 +26,6 @@ module.exports = {
         "content", "each", "else", "error", "extend", "for", "function", "if", "include", "mixin", "return", "use",
       ],
     }],
-    "block-closing-brace-newline-after": ["always", {
-      // allow @else to come on same line as closing @if brace
-      ignoreAtRules: ["else", "if"],
-    }],
     "scss/at-extend-no-missing-placeholder": true,
     "scss/at-function-pattern": namingPattern,
     "scss/at-import-no-partial-leading-underscore": true,


### PR DESCRIPTION
`block-closing-brace-newline-after` was [deprecated in stylelint 15.0.0](https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules) as it is a stylistic rule that should be enforced by a formatter instead.