### PR TITLE
Disable import-notation rule

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -26,6 +26,9 @@ module.exports = {
         "content", "each", "else", "error", "extend", "for", "function", "if", "include", "mixin", "return", "use",
       ],
     }],
+    // We don't want stylelint to flag `@import "mixins"` since that's not equivalent
+    // to `@import url("mixins")` in Sass.
+    "import-notation": null,
     "scss/at-extend-no-missing-placeholder": true,
     "scss/at-function-pattern": namingPattern,
     "scss/at-import-no-partial-leading-underscore": true,


### PR DESCRIPTION
This rule is problematic with SASS because contrary to the CSS spec, `@import "mixins"` isn't the same as `@import url("mixins")`. Since it's possible to have both CSS and SCSS imports, better to turn this off.

See also https://github.com/stylelint-scss/stylelint-config-recommended-scss/issues/163