### PR TITLE
Change at-mixin-argumentless-call-parentheses to never

### DIFF
--- a/sass.js
+++ b/sass.js
@@ -30,7 +30,7 @@ module.exports = {
     "scss/at-function-pattern": namingPattern,
     "scss/load-no-partial-leading-underscore": true,
     "scss/at-import-partial-extension-disallowed-list": ["scss"],
-    "scss/at-mixin-argumentless-call-parentheses": "always",
+    "scss/at-mixin-argumentless-call-parentheses": "never",
     "scss/at-mixin-pattern": namingPattern,
     "scss/dollar-variable-no-missing-interpolation": true,
     "scss/dollar-variable-pattern": namingPattern,


### PR DESCRIPTION
This matches what stylelint-config-standard-scss uses: https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/d0feabca7e43ddcb033f0636ccdeb4ca9b0671ad/index.js#L28